### PR TITLE
adding support for reconciling multiple approvals for the same component

### DIFF
--- a/code_center_component_import.py
+++ b/code_center_component_import.py
@@ -6,6 +6,9 @@ from pprint import pprint
 
 from blackduck.HubRestApi import HubInstance
 
+class ApprovalStatusConflict(Exception):
+	pass
+
 
 class CodeCenterComponentImport(object):
 	# Map from Code Center (catalog) approval status to Black Duck Hub approval status
@@ -43,6 +46,18 @@ class CodeCenterComponentImport(object):
 		self.hub_instance = hub_instance
 
 	def _update_approval_status(self, protex_component_id, protex_approval_status, protex_release_id=None):
+		'''Given a Protex component info (component id, release id, approval status) import the component
+		approval into the Black Duck Hub.
+
+		The steps include:
+		- Looking up the corresponding Hub KB component id, version id
+		- Comparing the approval statuses to see if there is a change
+		- Updating the Hub component approval status accordingly
+
+		The KB's for Protex and the Hub are not the same so in some (rare) cases the lookup will fail.
+
+		Returns a result which will be one of "Updated", "Equal" (no action), or "Failed"
+		'''
 		result = 'Failed'
 		protex_release_id = None if protex_release_id == "null" else protex_release_id
 		logging.debug("Searching for Protex component with ID {} and version ID {}".format(protex_component_id, protex_release_id))
@@ -65,7 +80,6 @@ class CodeCenterComponentImport(object):
 				component_or_version_details = self.hub_instance.get_component_by_url(details_url)
 
 				if component_or_version_details and 'approvalStatus' in component_or_version_details:
-					# logging.debug("Hub component or component version before update: {}".format(component_or_version_details))
 					current_approval_status = component_or_version_details['approvalStatus']
 					new_approval_status = CodeCenterComponentImport.APPROVAL_STATUS_MAP[protex_approval_status]
 
@@ -87,7 +101,6 @@ class CodeCenterComponentImport(object):
 					
 					component_or_version_details = self.hub_instance.get_component_by_url(details_url)
 					logging.debug("approvalStatus after update: {}".format(component_or_version_details['approvalStatus']))
-					# logging.debug("Hub component or component version after update: {}".format(component_or_version_details))
 				else:
 					logging.error("Hmm, that's odd, the Hub component/version didn't have an 'approvalStatus' field ({})".format(
 						component_or_version_details))
@@ -101,20 +114,171 @@ class CodeCenterComponentImport(object):
 		finally:
 			return result
 
+	def _get_protex_info(self, suite_component_info):
+		'''Given a row from the CSV file, with the Suite component info, return the Protex
+		component id, release/version id, and approval status
+		'''
+		try:
+			component_id = suite_component_info[CodeCenterComponentImport.COMPONENT_ID_COL_NAME]
+			version_id = suite_component_info[CodeCenterComponentImport.RELEASE_ID_COL_NAME]
+			approval_status = suite_component_info[CodeCenterComponentImport.APPROVAL_COL_NAME]
+		except KeyError:
+			logging.error("Missing required key in component info ({}), skipping...".format(suite_component_info))
+			return (None, None, None)
+		else:
+			return (component_id, version_id, approval_status)
+
+	def _import_component(self, suite_component_info):
+		component_id, version_id, approval_status = self._get_protex_info(suite_component_info)
+		return self._update_approval_status(component_id, approval_status, version_id)
+
+	def _set_hub_component_to_unreviewd(self, suite_component_info):
+		protex_component_id, protex_release_id, protex_approval_status = self._get_protex_info(suite_component_info)
+		# overwrite the approval status to un-reviewed
+		protex_approval_status = 'NOT_REVIEWED'
+		return self._update_approval_status(protex_component_id, protex_approval_status, protex_release_id)
+
+	def reset_components_to_unreviewed(self):
+		'''Parse a given CSV file and reset the approval status (in Hub) for any components found
+		'''
+		with open(args.component_approval_status_export, newline='') as component_list_file:
+			reader = csv.DictReader(component_list_file, delimiter="|")
+			for suite_component_info in reader:
+				component_type = "STANDARD" 
+				if component_type in CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES:
+					try:
+						self._set_hub_component_to_unreviewd(suite_component_info)
+					except:
+						logging.error("Failed to set component to unreviewed: {}".format(suite_component_info), exc_info=True)
+				else:
+					logging.debug("component type {} not in support component types ({})".format(
+						component_type, CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES))
+
+	def _reconcile_component_approvals(self, component_name_and_version, component_approvals):
+		# Given a list of component approvals (for the same component/name), determine if there is
+		# any conflict in the approval status values and, if not, choose an appropriate record
+		# to use for updating the Hub. 
+		# Note that Protex/CC status values of 'PENDING', 'MOREINFO', 'NOTSUBMITTED' all map to UNREVIEWED
+		statuses = set([c['approval_status'] for c in component_approvals])
+		if 'REJECTED' in statuses and 'APPROVED' in statuses:
+			raise ApprovalStatusConflict("component {} has conflicting status values ({})".format(
+				component_name_and_version, component_approvals))
+		elif 'APPROVED' in statuses:
+			# Choose the first APPROVED
+			suite_component_info = list(filter(
+				lambda ca: ca['approval_status'] == 'APPROVED', component_approvals))[0]
+		elif 'REJECTED' in statuses:
+			# Choose the first REJECTED
+			suite_component_info = list(filter(
+				lambda ca: ca['approval_status'] == 'REJECTED', component_approvals))[0]
+		else:
+			# Choose the first in the list
+			suite_component_info = component_approvals[0]
+		return suite_component_info
+
+	def import_components(self):
+		'''Import component approvals from CC
+
+		It is assumed that we have pulled the component approvals on a per-project basis so there can
+		be more than one approval request per component. And if there are > 1 approval requests for
+		any given component there is potentially a conflict which we must reconcile.
+		'''
+		with open(args.component_approval_status_export, newline='') as component_list_file:
+			reader = csv.DictReader(component_list_file, delimiter="|")
+			updated = []
+			conflicts = []
+			failed = []
+			equivalent = []
+
+			#
+			# Read all rows from the CSV file to compile a list of all
+			# component approval requests and create a set of component names/versions
+			#
+			all_rows_by_component_name_and_version = list()
+			all_component_names_and_versions = set()
+			for row in reader:
+				# list of tuples, first element is the key (component_name:component_version), 2nd element is the 
+				# row or suite_component_info 
+				all_rows_by_component_name_and_version.append(
+						("{}:{}".format(row['component_name'], row['component_version']), row)
+					)
+				# set of keys (component_name:component_version)
+				all_component_names_and_versions.add(
+					"{}:{}".format(row['component_name'], row['component_version']))
+
+			#
+			# look for any duplicate component approval requests and reconcile their approval status values 
+			# to decide whether we can update the component approval status in the Hub
+			#
+			for component_name_and_version in all_component_names_and_versions:
+				component_approvals = [
+					r[1] for r in all_rows_by_component_name_and_version if component_name_and_version == r[0]]
+				if len(component_approvals) == 1:
+					suite_component_info = component_approvals[0]
+				elif len(component_approvals) > 1:
+					try:
+						suite_component_info = self._reconcile_component_approvals(
+							component_name_and_version, component_approvals)
+					except ApprovalStatusConflict:
+						conflicts.append(component_approvals)
+						logging.warning(
+							"The component {} could not be imported due to an approval status conflict among the CC component approval requests ({})".format(
+								component_name_and_version, component_approvals))
+						continue
+				else:
+					logging.error("What? This is a bug cause we should never have 0 component approvals")
+					continue
+
+				#
+				# Update the Hub component approval status
+				#
+				result = self._import_component(suite_component_info)
+				if result == 'Updated':
+					logging.info("Updated the Hub with suite component: {}".format(suite_component_info))
+					updated.append(suite_component_info)
+				elif result == 'Equal':
+					logging.debug(
+						"Suite component approval status in Protex is effectively equal to the Hub for component: {}".format(
+							suite_component_info))
+					equivalent.append(suite_component_info)
+				else:
+					logging.warn("Failed to update suite component: {}".format(suite_component_info))
+					failed.append(suite_component_info)
+
+			#
+			# Dump the results
+			#
+			logging.info("Updated {} suite components or component versions".format(len(updated)))
+			self._dump_updated_to_file(updated)
+
+			if len(equivalent) > 0:
+				logging.info("Did not update {} suite components because the approval status they map to is equal to the existing Hub component approval status".format(
+					len(equivalent)))
+				self._dump_equivalent_to_file(equivalent)
+
+			if len(failed) > 0:
+				logging.info("Failed to update {} suite components or component versions".format(len(failed)))
+				self._dump_failed_to_file(failed)
+			if len(conflicts) > 0:
+				logging.info(
+					"Skipped {} suite components or component versions because there were approval status conflicts".format(
+						len(conflicts))
+					)
+				self._dump_conflicts(conflicts)
+
 	def _dump_updated_to_file(self, failed):
 		self._dump_to_file(failed, "-updated.csv")
 
 	def _dump_failed_to_file(self, failed):
 		self._dump_to_file(failed, "-failed.csv")
 
-	def _dump_skipped_to_file(self, skipped):
-		self._dump_to_file(skipped, "-skipped.csv")
+	def _dump_conflicts(self, skipped):
+		self._dump_to_file(skipped, "-conflicts.csv")
 		
 	def _dump_equivalent_to_file(self, equivalent):
 		self._dump_to_file(equivalent, "-equivalent.csv")
 		
 	def _dump_to_file(self, component_list, extension):
-		# import pdb; pdb.set_trace()
 		dump_csv_file = self.component_approval_status_export_file.replace(".csv", extension)
 		with open(dump_csv_file, 'w', newline='') as csvfile:
 			fieldnames = [
@@ -139,101 +303,6 @@ class CodeCenterComponentImport(object):
 				writer.writerow(component)
 		logging.info("Dumped {} components into {}".format(len(component_list), dump_csv_file))
 
-	def _get_protex_info(self, suite_component_info):
-		try:
-			component_id = suite_component_info[CodeCenterComponentImport.COMPONENT_ID_COL_NAME]
-			version_id = suite_component_info[CodeCenterComponentImport.RELEASE_ID_COL_NAME]
-			approval_status = suite_component_info[CodeCenterComponentImport.APPROVAL_COL_NAME]
-		except KeyError:
-			logging.error("Missing required key in component info ({}), skipping...".format(suite_component_info))
-			return (None, None, None)
-		else:
-			return (component_id, version_id, approval_status)
-
-	def _import_component(self, suite_component_info):
-		# try:
-		# 	component_id = suite_component_info[CodeCenterComponentImport.COMPONENT_ID_COL_NAME]
-		# 	version_id = suite_component_info[CodeCenterComponentImport.RELEASE_ID_COL_NAME]
-		# 	approval_status = suite_component_info[CodeCenterComponentImport.APPROVAL_COL_NAME]
-		# except KeyError:
-		# 	logging.error("Missing required key in component info ({}), skipping...".format(suite_component_info))
-		# 	return False
-		component_id, version_id, approval_status = self._get_protex_info(suite_component_info)
-		return self._update_approval_status(component_id, approval_status, version_id)
-
-	def _set_hub_component_to_unreviewd(self, suite_component_info):
-		protex_component_id, protex_release_id, protex_approval_status = self._get_protex_info(suite_component_info)
-		# overwrite the approval status to un-reviewed
-		protex_approval_status = 'NOT_REVIEWED'
-		return self._update_approval_status(protex_component_id, protex_approval_status, protex_release_id)
-
-	def reset_components_to_unreviewed(self):
-		with open(args.component_approval_status_export, newline='') as component_list_file:
-			reader = csv.DictReader(component_list_file, delimiter="|")
-			updated = []
-			failed = []
-			skipped = []
-			for suite_component_info in reader:
-				component_type = "STANDARD" 
-				if component_type in CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES:
-					try:
-						self._set_hub_component_to_unreviewd(suite_component_info)
-					except:
-						logging.error("Failed to set component to unreviewed: {}".format(suite_component_info), exc_info=True)
-				else:
-					logging.debug("component type {} not in support component types ({})".format(
-						component_type, CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES))
-
-	def import_components(self):
-		with open(args.component_approval_status_export, newline='') as component_list_file:
-			reader = csv.DictReader(component_list_file, delimiter="|")
-			updated = []
-			failed = []
-			equivalent = []
-			skipped = []
-			for suite_component_info in reader:
-				import pdb; pdb.set_trace()
-				# if component type not given, default to STANDARD (i.e. KB component)
-				# component_type = suite_component_info.get(CodeCenterComponentImport.COMPONENT_TYPE_COL_NAME, "STANDARD")
-				# TODO: Fix this once we have the component type info restored
-				component_type = "STANDARD" 
-				if component_type in CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES:
-					import pdb; pdb.set_trace()
-					logging.debug("Importing suite component: {}".format(suite_component_info))
-					result = self._import_component(suite_component_info)
-					if result == 'Updated':
-						logging.info("Updated the Hub with suite component: {}".format(suite_component_info))
-						updated.append(suite_component_info)
-					elif result == 'Equal':
-						logging.debug(
-							"Suite component approval status in Protex is effectively equal to the Hub for component: {}".format(
-								suite_component_info))
-						equivalent.append(suite_component_info)
-					else:
-						logging.warn("Failed to update suite component: {}".format(suite_component_info))
-						failed.append(suite_component_info)
-				else:
-					logging.debug("Skipping suite component because the type ({}) is not in supported types ({})".format(
-						component_type, CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES))
-					skipped.append(suite_component_info)
-
-			logging.info("Updated {} suite components or component versions".format(len(updated)))
-			self._dump_updated_to_file(updated)
-
-			if len(equivalent) > 0:
-				logging.info("Did not update {} suite components because the approval status they map to is equal to the existing Hub component approval status".format(
-					len(equivalent)))
-				self._dump_equivalent_to_file(equivalent)
-
-			if len(failed) > 0:
-				logging.info("Failed to update {} suite components or component versions".format(len(failed)))
-				self._dump_failed_to_file(failed)
-			if len(skipped) > 0:
-				logging.info(
-					"Skipped {} suite components or component versions because their type was not in {} types".format(
-						len(skipped), CodeCenterComponentImport.SUPPORTED_COMPONENT_TYPES)
-					)
-				self._dump_skipped_to_file(skipped)
 
 if __name__ == "__main__":
 	import argparse

--- a/code_center_component_import.py
+++ b/code_center_component_import.py
@@ -220,7 +220,7 @@ class CodeCenterComponentImport(object):
 						suite_component_info = self._reconcile_component_approvals(
 							component_name_and_version, component_approvals)
 					except ApprovalStatusConflict:
-						conflicts.append(component_approvals)
+						conflicts.extend(component_approvals)
 						logging.warning(
 							"The component {} could not be imported due to an approval status conflict among the CC component approval requests ({})".format(
 								component_name_and_version, component_approvals))
@@ -266,14 +266,16 @@ class CodeCenterComponentImport(object):
 					)
 				self._dump_conflicts(conflicts)
 
-	def _dump_updated_to_file(self, failed):
-		self._dump_to_file(failed, "-updated.csv")
+	def _dump_updated_to_file(self, updated):
+		import pdb; pdb.set_trace()
+		self._dump_to_file(updated, "-updated.csv")
 
 	def _dump_failed_to_file(self, failed):
 		self._dump_to_file(failed, "-failed.csv")
 
-	def _dump_conflicts(self, skipped):
-		self._dump_to_file(skipped, "-conflicts.csv")
+	def _dump_conflicts(self, conflicts):
+		import pdb; pdb.set_trace()
+		self._dump_to_file(conflicts, "-conflicts.csv")
 		
 	def _dump_equivalent_to_file(self, equivalent):
 		self._dump_to_file(equivalent, "-equivalent.csv")


### PR DESCRIPTION
Added code that will first determine if we have more than one approval/rejection for the same component, and then attempts to reconcile the approval statuses if we find any.